### PR TITLE
Adds support for udp and manual peer configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,16 @@ Dependencies
 Commands
 --------
 
-```send <size in megabytes>``` will create a new temporary IPFS node and host
-specified amount of random data for others to get. Note the file hash reference
-on command output.
+```send [--udp] <size in megabytes>``` will create a new temporary IPFS node and host
+specified amount of random data for others to get. The optional ```--udp``` switch will
+use the UDP/µTP transport instead of TCP. Note the local addresses and the file hash
+reference on command output.
 
-```receive <data ref>``` will create a new temporary IPFS node and download the
-data specified by the hash reference. It will also collect benchmark data about
-the download and finally show a graph.
+```receive [--udp] [--connect <sender address>] <data ref>``` will create a new temporary IPFS
+node and download the data specified by the hash reference. It will also collect benchmark
+data about the download and finally show a graph. The optional ```--udp`` switch will 
+use the UDP/µTP instead of TCP. If applicable you can expliciy specify the address of the
+send node by adding ```--connect <sender address>```
 
 The suggested way to do benchmarks is to run ```send``` on one host and
 ```receive``` on another. Varying network conditions will produce corresponding

--- a/receive
+++ b/receive
@@ -1,8 +1,31 @@
 #!/bin/sh
 
-[ $# -ne 1 ] && echo -e "Usage: $0 <data ref>" && exit
+[ $# -lt 1 ] && display_help=true
 
-REF=$1
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+
+    case $key in
+        -u|--udp)
+            use_udp=true
+            ;;
+        -h|--help)
+            display_help=true
+            ;;
+        -c|--connect)
+            connect_to_specific=true
+            shift
+            REMOTE_PEER_ADDRESS=$1
+            ;;
+        *)
+            REF=$key
+        ;;
+    esac
+    shift
+done
+
+[ "$display_help" = true -o -z "$REF" ] && echo "Usage: $0 [--udp] [--connect <address>] <data ref>" && exit
 
 set -em
 
@@ -12,6 +35,12 @@ set -em
 export IPFS_PATH=$(pwd)/ipfs_receive
 mkdir -p $IPFS_PATH
 $IPFS_BIN init
+
+# Modify the swarm addresses in case udp should be used
+if [ "$use_udp" = true ] ; then
+    $IPFS_BIN config --json Addresses.Swarm \
+        '["/ip4/0.0.0.0/udp/4001/utp", "/ip6/::/udp/4001/utp"]'
+fi
 
 # Start the daemon
 set -m
@@ -29,6 +58,11 @@ until $IPFS_BIN swarm peers >/dev/null 2>&1; do
 	echo -n .
 	sleep 0.2
 done
+
+# If needed to connect to specific peer
+if [ "connect_to_specific" = true ] ; then
+    $IPFS_BIN swarm connect $REMOTE_PEER_ADDRESS
+fi
 
 # Move to data directory
 mkdir -p data

--- a/receive
+++ b/receive
@@ -60,7 +60,7 @@ until $IPFS_BIN swarm peers >/dev/null 2>&1; do
 done
 
 # If needed to connect to specific peer
-if [ "connect_to_specific" = true ] ; then
+if [ "$connect_to_specific" = true ] ; then
     $IPFS_BIN swarm connect $REMOTE_PEER_ADDRESS
 fi
 

--- a/receive
+++ b/receive
@@ -52,12 +52,12 @@ if [ "$use_interface" = true ] ; then
     ipv6=$(ip -f inet6 -o addr show $interface scope global |cut -d\  -f 7 | cut -d/ -f 1)
 fi
 
-# Modify ports to allow two ipfs instances on the same host
+# Configure the IP addresses that should be used
 $IPFS_BIN config --json Addresses \
 '{
-   "Swarm": [ "/ip4/'$ipv4'/tcp/4003", "/ip6/'$ipv6'/tcp/4003" ],
-   "API": "/ip4/127.0.0.1/tcp/5003",
-   "Gateway": "/ip4/127.0.0.1/tcp/8083"
+   "Swarm": [ "/ip4/'$ipv4'/tcp/4001", "/ip6/'$ipv6'/tcp/4001" ],
+   "API": "/ip4/127.0.0.1/tcp/5001",
+   "Gateway": "/ip4/127.0.0.1/tcp/8081"
 }'
 
 # Modify the swarm addresses in case udp should be used

--- a/receive
+++ b/receive
@@ -10,6 +10,9 @@ do
         -u|--udp)
             use_udp=true
             ;;
+        -nm|--no-mdns)
+            disable_mdns=true
+            ;;
         -h|--help)
             display_help=true
             ;;
@@ -25,7 +28,7 @@ do
     shift
 done
 
-[ "$display_help" = true -o -z "$REF" ] && echo "Usage: $0 [--udp] [--connect <address>] <data ref>" && exit
+[ "$display_help" = true -o -z "$REF" ] && echo "Usage: $0 [--udp] [--no-mdns] [--connect <address>] <data ref>" && exit
 
 set -em
 
@@ -40,6 +43,11 @@ $IPFS_BIN init
 if [ "$use_udp" = true ] ; then
     $IPFS_BIN config --json Addresses.Swarm \
         '["/ip4/0.0.0.0/udp/4001/utp", "/ip6/::/udp/4001/utp"]'
+fi
+
+# Disable mdns discovery if needed
+if [ "$disable_mdns" = true ] ; then
+    $IPFS_BIN config Discovery.MDNS.Enabled false --json
 fi
 
 # Start the daemon

--- a/receive
+++ b/receive
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 [ $# -lt 1 ] && display_help=true
 
@@ -70,7 +70,7 @@ cd data
 rm -f ipfs.rrd
 
 # Start data collection
-../ipfs-benchmark/ipfs-collect &
+./ipfs-benchmark/ipfs-collect data &
 
 trap "trap - SIGINT SIGTERM EXIT; \
       kill $IPFS_PID; \

--- a/receive
+++ b/receive
@@ -70,7 +70,7 @@ cd data
 rm -f ipfs.rrd
 
 # Start data collection
-./ipfs-benchmark/ipfs-collect data &
+../ipfs-benchmark/ipfs-collect &
 
 trap "trap - SIGINT SIGTERM EXIT; \
       kill $IPFS_PID; \

--- a/receive
+++ b/receive
@@ -7,19 +7,24 @@ do
     key="$1"
 
     case $key in
-        -u|--udp)
-            use_udp=true
-            ;;
-        -nm|--no-mdns)
-            disable_mdns=true
-            ;;
-        -h|--help)
-            display_help=true
-            ;;
         -c|--connect)
             connect_to_specific=true
             shift
             REMOTE_PEER_ADDRESS=$1
+            ;;
+        -h|--help)
+            display_help=true
+            ;;
+        -i|--interface)
+            use_interface=true
+            shift
+            interface=$1
+            ;;
+        -nm|--no-mdns)
+            disable_mdns=true
+            ;;
+        -u|--udp)
+            use_udp=true
             ;;
         *)
             REF=$key
@@ -28,7 +33,7 @@ do
     shift
 done
 
-[ "$display_help" = true -o -z "$REF" ] && echo "Usage: $0 [--udp] [--no-mdns] [--connect <address>] <data ref>" && exit
+[ "$display_help" = true -o -z "$REF" ] && echo "Usage: $0 [--udp] [--interface <interface>] [--no-mdns] [--connect <address>] <data ref>" && exit
 
 set -em
 
@@ -39,10 +44,26 @@ export IPFS_PATH=$(pwd)/ipfs_receive
 mkdir -p $IPFS_PATH
 $IPFS_BIN init
 
+ipv4="0.0.0.0"
+ipv6="::"
+
+if [ "$use_interface" = true ] ; then
+    ipv4=$(ip -f inet -o addr show $interface scope global |cut -d\  -f 7 | cut -d/ -f 1)
+    ipv6=$(ip -f inet6 -o addr show $interface scope global |cut -d\  -f 7 | cut -d/ -f 1)
+fi
+
+# Modify ports to allow two ipfs instances on the same host
+$IPFS_BIN config --json Addresses \
+'{
+   "Swarm": [ "/ip4/'$ipv4'/tcp/4003", "/ip6/'$ipv6'/tcp/4003" ],
+   "API": "/ip4/127.0.0.1/tcp/5003",
+   "Gateway": "/ip4/127.0.0.1/tcp/8083"
+}'
+
 # Modify the swarm addresses in case udp should be used
 if [ "$use_udp" = true ] ; then
     $IPFS_BIN config --json Addresses.Swarm \
-        '["/ip4/0.0.0.0/udp/4001/utp", "/ip6/::/udp/4001/utp"]'
+        '["/ip4/'$ipv4'/udp/4001/utp", "/ip6/'$ipv6'/udp/4001/utp"]'
 fi
 
 # Disable mdns discovery if needed

--- a/send
+++ b/send
@@ -50,7 +50,7 @@ fi
 # Modify ports to allow two ipfs instances on the same host
 $IPFS_BIN config --json Addresses \
 '{
-   "Swarm": [ "/ip4/$ipv4/tcp/4002", "/ip6/$ipv6/tcp/4002" ],
+   "Swarm": [ "/ip4/'$ipv4'/tcp/4002", "/ip6/'$ipv6'/tcp/4002" ],
    "API": "/ip4/127.0.0.1/tcp/5002",
    "Gateway": "/ip4/127.0.0.1/tcp/8082"
 }'
@@ -58,7 +58,7 @@ $IPFS_BIN config --json Addresses \
 # Modify the swarm addresses in case udp should be used
 if [ "$use_udp" = true ] ; then
     $IPFS_BIN config --json Addresses.Swarm \
-        '["/ip4/$ipv4/udp/4002/utp", "/ip6/$ipv6/udp/4002/utp"]'
+        '["/ip4/'$ipv4'/udp/4002/utp", "/ip6/'$ipv6'/udp/4002/utp"]'
 fi
 
 # Disable mdns discovery if needed

--- a/send
+++ b/send
@@ -7,19 +7,19 @@ do
     key="$1"
 
     case $key in
-        -u|--udp)
-            use_udp=true
-            ;;
-        -nm|--no-mdns)
-            disable_mdns=true
+        -h|--help)
+            display_help=true
             ;;
         -i|--interface)
             use_interface=true
             shift
             interface=$1
             ;;
-        -h|--help)
-            display_help=true
+        -nm|--no-mdns)
+            disable_mdns=true
+            ;;
+        -u|--udp)
+            use_udp=true
             ;;
         *)
             DATA_SIZE=$key

--- a/send
+++ b/send
@@ -66,6 +66,9 @@ echo "Generating test data..."
 ref=$(dd if=/dev/urandom iflag=fullblock bs=1M count=$DATA_SIZE \
       | $IPFS_BIN add -q)
 
+# Display addresses
+$IPFS_BIN id -f="<addrs>\n"
+
 # Wait for signal
 echo "Sender started with $ref"
 echo "Press ctrl-C to stop"

--- a/send
+++ b/send
@@ -13,6 +13,11 @@ do
         -nm|--no-mdns)
             disable_mdns=true
             ;;
+        -i|--interface)
+            use_interface=true
+            shift
+            interface=$1
+            ;;
         -h|--help)
             display_help=true
             ;;
@@ -23,7 +28,7 @@ do
     shift
 done
 
-[ "$display_help" = true -o -z "$DATA_SIZE" ] && echo "Usage: $0 [--udp] [--no-mdns] <size in megabytes>" && exit
+[ "$display_help" = true -o -z "$DATA_SIZE" ] && echo "Usage: $0 [--udp] [--interface <interface>] [--no-mdns] <size in megabytes>" && exit
 
 set -em
 
@@ -34,10 +39,18 @@ export IPFS_PATH=ipfs_send
 mkdir -p $IPFS_PATH
 $IPFS_BIN init
 
+ipv4 = "0.0.0.0"
+ipv6 = "::"
+
+if [ "$use_interface" = true ] ; then
+    ipv4 = $(ip -f inet -o addr show $interface scope global |cut -d\  -f 7 | cut -d/ -f 1)
+    ipv6 = $(ip -f inet6 -o addr show $interface scope global |cut -d\  -f 7 | cut -d/ -f 1)
+fi
+
 # Modify ports to allow two ipfs instances on the same host
 $IPFS_BIN config --json Addresses \
 '{
-   "Swarm": [ "/ip4/0.0.0.0/tcp/4002", "/ip6/::/tcp/4002" ],
+   "Swarm": [ "/ip4/$ipv4/tcp/4002", "/ip6/$ipv6/tcp/4002" ],
    "API": "/ip4/127.0.0.1/tcp/5002",
    "Gateway": "/ip4/127.0.0.1/tcp/8082"
 }'
@@ -45,7 +58,7 @@ $IPFS_BIN config --json Addresses \
 # Modify the swarm addresses in case udp should be used
 if [ "$use_udp" = true ] ; then
     $IPFS_BIN config --json Addresses.Swarm \
-        '["/ip4/0.0.0.0/udp/4002/utp", "/ip6/::/udp/4002/utp"]'
+        '["/ip4/$ipv4/udp/4002/utp", "/ip6/$ipv6/udp/4002/utp"]'
 fi
 
 # Disable mdns discovery if needed

--- a/send
+++ b/send
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-[ $# -lt 1 ] && display_help=true && ipv4="0.0.0.0" && ipv6="::"
+[ $# -lt 1 ] && display_help=true
 
 while [[ $# -gt 0 ]]
 do
@@ -39,9 +39,12 @@ export IPFS_PATH=ipfs_send
 mkdir -p $IPFS_PATH
 $IPFS_BIN init
 
+ipv4="0.0.0.0"
+ipv6="::"
+
 if [ "$use_interface" = true ] ; then
-    export ipv4 = $(ip -f inet -o addr show $interface scope global |cut -d\  -f 7 | cut -d/ -f 1)
-    export ipv6 = $(ip -f inet6 -o addr show $interface scope global |cut -d\  -f 7 | cut -d/ -f 1)
+    ipv4=$(ip -f inet -o addr show $interface scope global |cut -d\  -f 7 | cut -d/ -f 1)
+    ipv6=$(ip -f inet6 -o addr show $interface scope global |cut -d\  -f 7 | cut -d/ -f 1)
 fi
 
 # Modify ports to allow two ipfs instances on the same host

--- a/send
+++ b/send
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-[ $# -lt 1 ] && display_help=true
+[ $# -lt 1 ] && display_help=true && ipv4="0.0.0.0" && ipv6="::"
 
 while [[ $# -gt 0 ]]
 do
@@ -39,12 +39,9 @@ export IPFS_PATH=ipfs_send
 mkdir -p $IPFS_PATH
 $IPFS_BIN init
 
-ipv4 = "0.0.0.0"
-ipv6 = "::"
-
 if [ "$use_interface" = true ] ; then
-    ipv4 = $(ip -f inet -o addr show $interface scope global |cut -d\  -f 7 | cut -d/ -f 1)
-    ipv6 = $(ip -f inet6 -o addr show $interface scope global |cut -d\  -f 7 | cut -d/ -f 1)
+    export ipv4 = $(ip -f inet -o addr show $interface scope global |cut -d\  -f 7 | cut -d/ -f 1)
+    export ipv6 = $(ip -f inet6 -o addr show $interface scope global |cut -d\  -f 7 | cut -d/ -f 1)
 fi
 
 # Modify ports to allow two ipfs instances on the same host

--- a/send
+++ b/send
@@ -1,8 +1,26 @@
-#!/bin/sh
+#!/bin/bash
 
-[ $# -ne 1 ] && echo -e "Usage: $0 <size in megabytes>" && exit
+[ $# -lt 1 ] && display_help=true
 
-DATA_SIZE=$1 # megabytes
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+
+    case $key in
+        -u|--udp)
+            use_udp=true
+            ;;
+        -h|--help)
+            display_help=true
+            ;;
+        *)
+            DATA_SIZE=$key
+        ;;
+    esac
+    shift
+done
+
+[ "$display_help" = true -o -z "$DATA_SIZE" ] && echo "Usage: $0 [--udp] <size in megabytes>" && exit
 
 set -em
 
@@ -20,6 +38,12 @@ $IPFS_BIN config --json Addresses \
    "API": "/ip4/127.0.0.1/tcp/5002",
    "Gateway": "/ip4/127.0.0.1/tcp/8082"
 }'
+
+# Modify the swarm addresses in case udp should be used
+if [ "$use_udp" = true ] ; then
+    $IPFS_BIN config --json Addresses.Swarm \
+        '["/ip4/0.0.0.0/udp/4002/utp", "/ip6/::/udp/4002/utp"]'
+fi
 
 # Start the daemon
 $IPFS_BIN daemon &

--- a/send
+++ b/send
@@ -10,6 +10,9 @@ do
         -u|--udp)
             use_udp=true
             ;;
+        -nm|--no-mdns)
+            disable_mdns=true
+            ;;
         -h|--help)
             display_help=true
             ;;
@@ -20,7 +23,7 @@ do
     shift
 done
 
-[ "$display_help" = true -o -z "$DATA_SIZE" ] && echo "Usage: $0 [--udp] <size in megabytes>" && exit
+[ "$display_help" = true -o -z "$DATA_SIZE" ] && echo "Usage: $0 [--udp] [--no-mdns] <size in megabytes>" && exit
 
 set -em
 
@@ -43,6 +46,11 @@ $IPFS_BIN config --json Addresses \
 if [ "$use_udp" = true ] ; then
     $IPFS_BIN config --json Addresses.Swarm \
         '["/ip4/0.0.0.0/udp/4002/utp", "/ip6/::/udp/4002/utp"]'
+fi
+
+# Disable mdns discovery if needed
+if [ "$disable_mdns" = true ] ; then
+    $IPFS_BIN config Discovery.MDNS.Enabled false --json
 fi
 
 # Start the daemon


### PR DESCRIPTION
Hi,

Thanks for this excellent tool for benchmarking IPFS! I had some specific needs for my setup and made some changes that are backward compatible with your scripts and add some features I needed for my testing:
- Adds an optional `--udp` switch to both `send` and `receive` to enable the use of UDP instead of TCP.
- Adds an optional `--connect <remote peer address>` parameter to `receive` that enables connecting to a specific remote peer. This is useful for testing in networks without a DHT or multicast support.
- Displays the IPFS addresses the `send` program is listening on when starting `send`

Maybe they are useful for other as well...

Cheers,
Eelco
